### PR TITLE
Support setting variables to an empty value

### DIFF
--- a/autoload/shadowenv.vim
+++ b/autoload/shadowenv.vim
@@ -19,7 +19,7 @@ function! shadowenv#hook() abort
   "   ^         ^          ^
   "   export    FOO=       bar
   for l:instruction in split(l:contents, "\x1E")
-    let l:operands = split(l:instruction, "\x1F")
+    let l:operands = split(l:instruction, "\x1F", 1)
     let l:opcode = l:operands[0]
 
     if l:opcode == "\x01" " SET_UNEXPORTED


### PR DESCRIPTION
Sometimes the shadowenv hook will include variables that are to be set
to empty values. In these cases shadowenv.vim will error with `Invalid
expression: l:operands[2]`.

Vim's `split()` function will omit empty values at the beginning or end
of the resulting list. There exists however a third argument that will
instruct it to keep empty values.

ex:

  split('a|b|', '|') === ['a', 'b']

  split('a|b|', '|', 1) === ['a', 'b', '']