### PR TITLE
Ignore unexported values

### DIFF
--- a/autoload/shadowenv.vim
+++ b/autoload/shadowenv.vim
@@ -3,7 +3,6 @@
 " Version: 0.1
 
 let s:shadowenv_binary = get(g:, 'shadowenv_binary', 'shadowenv')
-let s:shadowenv_data = ''
 
 function! shadowenv#hook() abort
   if !executable(s:shadowenv_binary)
@@ -11,7 +10,7 @@ function! shadowenv#hook() abort
     return
   endif
 
-  let l:contents = system(s:shadowenv_binary . " hook --porcelain '" . s:shadowenv_data . "' 2>/dev/null")
+  let l:contents = system(s:shadowenv_binary . " hook --porcelain 2>/dev/null")
 
   " Fields separated by 0x1F; records separated by 0x1E.
   " example message:
@@ -23,14 +22,7 @@ function! shadowenv#hook() abort
     let l:opcode = l:operands[0]
 
     if l:opcode == "\x01" " SET_UNEXPORTED
-      " __shadowenv_data specifically is set, but not exported to
-      " subprocesses. It lives only in the shell session itself as an
-      " unexported variable.
-      if l:operands[1] != '__shadowenv_data'
-        echoerr 'unrecognized operand for SET_UNEXPORTED operation: '.l:operands[1]
-        return
-      endif
-      let s:shadowenv_data = l:operands[2]
+      " ignored
     elseif l:opcode == "\x02" " SET_EXPORTED
       execute('let $'.l:operands[1].' = l:operands[2]')
     elseif l:opcode == "\x03" " UNSET


### PR DESCRIPTION
Following the deprecation of unexported values and how they're ignored
in vscode-shadowenv.